### PR TITLE
Support offline compilation of `SQLx` macros

### DIFF
--- a/.sqlx/query-2316417fe1c515f73c756815c656091d5b61c34bf196e48a1d3863115bc8ab00.json
+++ b/.sqlx/query-2316417fe1c515f73c756815c656091d5b61c34bf196e48a1d3863115bc8ab00.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "SQLite",
+  "query": "\n        SELECT\n            Id as id,\n            DisplayName as display_name,\n            Email as email,\n            PasswordHash as password_hash,\n            CreatedAt as created_at,\n            UpdatedAt as updated_at\n        FROM Nomer WHERE Email = ?\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id",
+        "ordinal": 0,
+        "type_info": "Integer"
+      },
+      {
+        "name": "display_name",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "email",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "password_hash",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "created_at",
+        "ordinal": 4,
+        "type_info": "Datetime"
+      },
+      {
+        "name": "updated_at",
+        "ordinal": 5,
+        "type_info": "Datetime"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "2316417fe1c515f73c756815c656091d5b61c34bf196e48a1d3863115bc8ab00"
+}

--- a/.sqlx/query-25b6ed63d2de5796a8eaee434c90a8d90c44cf725bd11766f6698135ecf43326.json
+++ b/.sqlx/query-25b6ed63d2de5796a8eaee434c90a8d90c44cf725bd11766f6698135ecf43326.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT COUNT(*) AS count FROM Nomer WHERE DisplayName = ? OR Email = ?",
+  "describe": {
+    "columns": [
+      {
+        "name": "count",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "25b6ed63d2de5796a8eaee434c90a8d90c44cf725bd11766f6698135ecf43326"
+}

--- a/.sqlx/query-d48dd68adc066d197d6ab6f6c64de7d86db3ffee42adae722c6234ecac2923d4.json
+++ b/.sqlx/query-d48dd68adc066d197d6ab6f6c64de7d86db3ffee42adae722c6234ecac2923d4.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "INSERT INTO Nomer (DisplayName, Email, PasswordHash) VALUES (?, ?, ?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "d48dd68adc066d197d6ab6f6c64de7d86db3ffee42adae722c6234ecac2923d4"
+}


### PR DESCRIPTION
This PR fixes a bug that prevents macros compilation. More specifically, SQLx macros require an actual database specified by `DATABASE_URL` environment variable. This is troublesome to implement in CI, so we allow this instead.