### PR TITLE
Change wrong routing string

### DIFF
--- a/src/routes/review/mod.rs
+++ b/src/routes/review/mod.rs
@@ -15,8 +15,8 @@ pub(super) fn make_router() -> Router<AppState> {
     Router::new()
         .route("/", post(create::handle))
         .route("/", get(read_many::handle))
-        .route("/:id", get(read_one::handle))
-        .route("/:id", delete(remove::handle))
+        .route("/{id}", get(read_one::handle))
+        .route("/{id}", delete(remove::handle))
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/routes/user/mod.rs
+++ b/src/routes/user/mod.rs
@@ -13,5 +13,5 @@ pub(super) fn make_router() -> Router<AppState> {
     Router::new()
         .route("/", post(create::handle))
         .route("/", get(fetch::handle))
-        .route("/:id", get(fetch_public::handle))
+        .route("/{id}", get(fetch_public::handle))
 }


### PR DESCRIPTION
Path capture groups are writtent with curly brackets, not colons.