### PR TITLE
Fix JSON serialisation issues

### DIFF
--- a/src/models/canteen.rs
+++ b/src/models/canteen.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::models::Store;
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Canteen {
     pub id: i64,
     pub name: String,

--- a/src/models/item.rs
+++ b/src/models/item.rs
@@ -2,6 +2,7 @@ use bigdecimal::BigDecimal;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Item {
     pub id: i64,
     pub name: String,

--- a/src/models/nomer.rs
+++ b/src/models/nomer.rs
@@ -13,6 +13,7 @@ use tracing::error;
 use crate::state::AppState;
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Nomer {
     pub id: i64,
     pub display_name: String,
@@ -76,6 +77,7 @@ impl FromRequestParts<AppState> for Nomer {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct NomerClaim {
     pub sub: String,
     pub exp: i64,

--- a/src/models/review.rs
+++ b/src/models/review.rs
@@ -2,6 +2,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Review {
     pub id: i64,
     pub nomer_id: i64,

--- a/src/models/store.rs
+++ b/src/models/store.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::models::Item;
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Store {
     pub id: i64,
     pub name: String,

--- a/src/routes/review/mod.rs
+++ b/src/routes/review/mod.rs
@@ -20,6 +20,7 @@ pub(super) fn make_router() -> Router<AppState> {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct DbReview {
     review_id: i64,
     score: i64,


### PR DESCRIPTION
By default, serde_json serialises JSON keys in snake_case. This commit updates the models to use the `#[serde(rename_all = "camelCase")]` macro to ensure that the JSON keys are in camelCase, which is the expected format for the API.